### PR TITLE
Added the grasp offset to robot description

### DIFF
--- a/custom/skills.yaml
+++ b/custom/skills.yaml
@@ -59,3 +59,4 @@ skills:
             left:  {x: 0.055, y: 0.0, z: 0.03, roll: 0.0, pitch: -0.2, yaw: 0.0}
             right: {x: 0.065, y: 0.0,  z: 0.03, roll: 0.0, pitch: -0.2, yaw: 0.0}
             marker_to_grippoint: {x: -0.03, y: 0.01, z: 0.03, roll: 0.0, pitch: 0.0, yaw: 0.0}
+            grasp_offset: {x: 0.5, y: 0.2, z: 0.03, roll: 0.0, pitch: 0.0, yaw: 0.0}

--- a/custom/skills.yaml
+++ b/custom/skills.yaml
@@ -59,4 +59,4 @@ skills:
             left:  {x: 0.055, y: 0.0, z: 0.03, roll: 0.0, pitch: -0.2, yaw: 0.0}
             right: {x: 0.065, y: 0.0,  z: 0.03, roll: 0.0, pitch: -0.2, yaw: 0.0}
             marker_to_grippoint: {x: -0.03, y: 0.01, z: 0.03, roll: 0.0, pitch: 0.0, yaw: 0.0}
-            grasp_offset: {x: 0.5, y: 0.2, z: 0.03, roll: 0.0, pitch: 0.0, yaw: 0.0}
+            grasp_offset: {x: 0.5, y: 0.2, z: 0.0, roll: 0.0, pitch: 0.0, yaw: 0.0}


### PR DESCRIPTION
Solution to issue #626. I think the roll, pitch and yaw variable are not necessary (they are also not imported in robot.py), but I wasn't sure whether they could just be left out. 